### PR TITLE
Allow single song repeat

### DIFF
--- a/Pod/Classes/AUMediaPlayer.h
+++ b/Pod/Classes/AUMediaPlayer.h
@@ -161,6 +161,13 @@ typedef NS_ENUM(NSUInteger, AUMediaPlaybackStatus){
  */
 - (void)playItemQueue:(id<AUMediaItemCollection>)collection error:(NSError * __autoreleasing *)error;
 /**
+ *  Plays given item while maintaining current queue.
+ *
+ *  @param item  Item to play.
+ *  @param error Error is assigned when playback fails.
+ */
+- (void)updatePlayerWithItem:(id<AUMediaItem>)item error:(NSError * __autoreleasing*)error;
+/**
  *  Resumes playback.
  */
 - (void)play;

--- a/Pod/Classes/AUMediaPlayer.h
+++ b/Pod/Classes/AUMediaPlayer.h
@@ -128,6 +128,7 @@ typedef NS_ENUM(NSUInteger, AUMediaPlaybackStatus){
  */
 @property (nonatomic, readonly) BOOL shuffle;
 @property (nonatomic, readonly) BOOL repeat;
+@property (nonatomic, readonly) BOOL repeatSong;
 @property (nonatomic, readonly) NSUInteger currentlyPlayedTrackIndex;
 @property (nonatomic, readonly) NSUInteger queueLength;
 /**
@@ -188,6 +189,14 @@ typedef NS_ENUM(NSUInteger, AUMediaPlaybackStatus){
  */
 - (void)playNext;
 /**
+ *  Plays next track from queue.
+ *  Passing in true for 'force' will ignore the repeatSong parameter.  This is useful if
+ *  you want to auto playnext to repeat the song, but when a user click a UI next button
+ *  move to the next item in the queue.
+ *  @param force Force the player to the next track regardless of repeatSong state
+ */
+- (void)playNextForced:(BOOL)force;
+/**
  *  Plays previous track from the queue.
  *  If playback is on 3. second or greater it just seeks to second 0.
  *  When currently played track's index in the queue is 0, it jums to the last track
@@ -204,6 +213,7 @@ typedef NS_ENUM(NSUInteger, AUMediaPlaybackStatus){
 
 - (void)setShuffleOn:(BOOL)shuffle;
 - (void)setRepeatOn:(BOOL)repeat;
+- (void)setRepeatSongOn:(BOOL)repeat;
 
 /**
  * Gets called before item replacement. Enables interaction with items and queues being played before new item appers.

--- a/Pod/Classes/AUMediaPlayer.m
+++ b/Pod/Classes/AUMediaPlayer.m
@@ -115,9 +115,20 @@ static void *AVPlayerPlaybackBufferEmptyObservationContext = &AVPlayerPlaybackBu
 }
 
 - (void)playNext {
+    [self playNextForced:NO];
+}
+
+- (void)playNextForced:(BOOL)force {
     NSError *error = nil;
     
-    NSUInteger nextTrackIndex = (self.currentlyPlayedTrackIndex + 1) % self.queue.count;
+    NSUInteger nextTrackIndex;
+    
+    if (_repeatSong && !force) {
+        nextTrackIndex = self.currentlyPlayedTrackIndex;
+    }else {
+        nextTrackIndex = (self.currentlyPlayedTrackIndex + 1) % self.queue.count;
+    }
+    
     id<AUMediaItem> nextItem = [self.playingQueue objectAtIndex:nextTrackIndex];
     [self updatePlayerWithItem:nextItem error:&error];
     
@@ -185,6 +196,10 @@ static void *AVPlayerPlaybackBufferEmptyObservationContext = &AVPlayerPlaybackBu
 
 - (void)setRepeatOn:(BOOL)repeat {
     _repeat = repeat;
+}
+
+- (void)setRepeatSongOn:(BOOL)repeat {
+    _repeatSong = repeat;
 }
 
 - (void)restorePlayerStateWithItem:(id<AUMediaItem>)item queue:(NSArray *)queue playbackTime:(CMTime)time error:(NSError *__autoreleasing *)error {


### PR DESCRIPTION
Created a repeatSong property.  
Added new method playNextForced:  This allows a UI next button to force the play of the next item regardless of the repeatSong state.

This closes #3 
