### PR TITLE
Add support for playing bundled files

### DIFF
--- a/Pod/Classes/AUMediaItem.h
+++ b/Pod/Classes/AUMediaItem.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSInteger, AUMediaType){
 
 @optional
 
-- (bool)isLocalItem;
+- (BOOL)isLocalItem;
 - (NSString *)localPath;
 
 @required

--- a/Pod/Classes/AUMediaItem.h
+++ b/Pod/Classes/AUMediaItem.h
@@ -30,6 +30,11 @@ typedef NS_ENUM(NSInteger, AUMediaType){
 
 @protocol AUMediaItem <NSObject, NSCoding>
 
+@optional
+
+- (bool)isLocalItem;
+- (NSString *)localPath;
+
 @required
 
 /*****************************************************************************

--- a/Pod/Classes/AUMediaPlayer.m
+++ b/Pod/Classes/AUMediaPlayer.m
@@ -279,6 +279,10 @@ static void *AVPlayerPlaybackBufferEmptyObservationContext = &AVPlayerPlaybackBu
     [self prepareForCurrentItemReplacementWithItem:item];
     
     NSURL *url = nil;
+    if([item isLocalItem]) {
+        url = [NSURL fileURLWithPath: [item localPath]];
+        NSLog(@"Playback will occur with a completely local item at: %@", url); 
+    }
     if ([_library itemIsDownloaded:item]) {
         url = [NSURL fileURLWithPath:[_library localPathForItem:item]];
         NSLog(@"Playback will occur from local file with url: %@", url);

--- a/Pod/Classes/AUMediaPlayer.m
+++ b/Pod/Classes/AUMediaPlayer.m
@@ -283,7 +283,7 @@ static void *AVPlayerPlaybackBufferEmptyObservationContext = &AVPlayerPlaybackBu
         url = [NSURL fileURLWithPath: [item localPath]];
         NSLog(@"Playback will occur with a completely local item at: %@", url); 
     }
-    if ([_library itemIsDownloaded:item]) {
+    if ([_library itemIsDownloaded:item] && !url) {
         url = [NSURL fileURLWithPath:[_library localPathForItem:item]];
         NSLog(@"Playback will occur from local file with url: %@", url);
     }

--- a/Pod/Classes/AUMediaPlayer.m
+++ b/Pod/Classes/AUMediaPlayer.m
@@ -281,7 +281,6 @@ static void *AVPlayerPlaybackBufferEmptyObservationContext = &AVPlayerPlaybackBu
     NSURL *url = nil;
     if([item isLocalItem]) {
         url = [NSURL fileURLWithPath: [item localPath]];
-        NSLog(@"Playback will occur with a completely local item at: %@", url); 
     }
     if ([_library itemIsDownloaded:item] && !url) {
         url = [NSURL fileURLWithPath:[_library localPathForItem:item]];


### PR DESCRIPTION
I've added support for creating objects conforming to AUMediaItem which represents a local, bundled file which doesn't need to be downloaded or managed separately. 

Two additional, optional methods are added to the protocol, and an additional check within updatePlayerWithItem.
